### PR TITLE
第三方引用时，不用手动通过scan的方式扫描装配，直接引用依赖即可

### DIFF
--- a/acmtc-redismq/src/main/java/com/acmtc/redisMQ/configuration/RedisMQConfiguration.java
+++ b/acmtc-redismq/src/main/java/com/acmtc/redisMQ/configuration/RedisMQConfiguration.java
@@ -1,0 +1,16 @@
+package com.acmtc.redisMQ.configuration;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @ClassName RedisMQConfiguration
+ * @Description 第三方引用时自动装配spring
+ * @Author cxy@acmtc.com
+ * @Date 2020/6/25 23:32
+ * @Version 1.0
+ */
+@Configuration
+@ComponentScan("com.acmtc")
+public class RedisMQConfiguration {
+}

--- a/acmtc-redismq/src/main/resources/META-INF/spring.factories
+++ b/acmtc-redismq/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.acmtc.redisMQ.configuration.RedisMQConfiguration


### PR DESCRIPTION
第三方引用时，不用手动通过scan的方式扫描装配，直接引用依赖即可